### PR TITLE
chore: remove workaround for SELECT.stream()

### DIFF
--- a/srv/travel-service.js
+++ b/srv/travel-service.js
@@ -124,7 +124,3 @@ module.exports = class TravelService extends cds.ApplicationService { async init
   return super.init()
 
 }}
-
-
-// Temporary monkey patch until upcoming release of @sap/cds...
-SELECT.class.prototype.stream ??= SELECT.class.prototype.pipeline


### PR DESCRIPTION
once cds 9.4 is released, we can remove the workaroung