### PR TITLE
fix: value help glitch

### DIFF
--- a/apis/capire/xflights.cds
+++ b/apis/capire/xflights.cds
@@ -8,6 +8,7 @@ namespace sap.capire.xflights;
  */
 @federated entity Flights as projection on external.Flights {
   ID, date, departure, arrival, free_seats, modifiedAt,
+  price, currency,
   airline.icon     as icon @UI.IsImageURL,
   airline.name     as airline,
   origin.name      as origin,


### PR DESCRIPTION
While creating a sample with xtravels, we noticed that the value help for the flights in the booking section is not working:

```
Failed to get contexts for /odata/v4/travel/Flights with start index 0 and length 34 - Invalid (navigation) property 'price' in $select
```

When price is added, the following is thrown:

```
Invalid (navigation) property 'currency_code' in $select
```

=> added price and currency to consumption view