### PR TITLE
chore: rm `direct_crud: true`

### DIFF
--- a/.cdsrc.yaml
+++ b/.cdsrc.yaml
@@ -3,4 +3,3 @@
     flow: xmpls/flow/
 fiori:
   draft_new_action: true
-  direct_crud: true


### PR DESCRIPTION
unnecessary with cds^10