### PR TITLE
feat: deploy to Staging

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-  pull_request: # temp
 
 permissions:
   contents: read

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -41,7 +41,17 @@ jobs:
       - run: npm add -D @sap/cds-dk
       - run: npm add @cap-js/hana @sap/xssec @sap-cloud-sdk/resilience
       - run: npm install
-      - run: npx cds up
+      - name: Write MTA extension with S/4 sandbox API key
+        run: |
+          cat > s4.mtaext <<EOF
+          _schema-version: "3.3.0"
+          ID: capire.xtravels.s4
+          extends: capire.xtravels
+          parameters:
+            s4-api-key: "${{ secrets.S4_KEY }}"
+          EOF
+        shell: bash
+      - run: npx cds up --overlay s4.mtaext
 
       - run: cf logs ${{ env.APP_NAME }}-srv --recent
         if: always()

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - uses: cap-js/cf-setup@v2
         with:
           api: ${{ vars.CF_API }}

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -1,0 +1,52 @@
+name: Cloud Foundry
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        default: Staging
+        type: string
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request: # temp
+
+permissions:
+  contents: read
+  deployments: write
+
+env:
+  APP_NAME: xtravels
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: cap-js/cf-setup@v2
+        with:
+          api: ${{ vars.CF_API }}
+          org: ${{ vars.CF_ORG }}
+          space: ${{ vars.CF_SPACE }}
+          username: ${{ vars.CF_USERNAME }}
+          password: ${{ secrets.CF_PASSWORD }}
+      - run: npm set @capire:registry https://npm.pkg.github.com/
+        shell: bash
+      - run: npm set //npm.pkg.github.com/:_authToken=${{ secrets.CAPIRE_READ_PACKAGES }}
+        shell: bash
+      - run: npm add -D @sap/cds-dk
+      - run: npm add @cap-js/hana @sap/xssec @sap-cloud-sdk/resilience
+      - run: npm install
+      - run: npx cds up
+
+      - run: cf logs ${{ env.APP_NAME }}-srv --recent
+        if: always()
+      - run: cf logs ${{ env.APP_NAME }}-db-deployer --recent
+        if: always()
+    environment:
+      name: ${{ inputs.environment || 'Staging' }}
+      url: https://sapcapiretravels-9mnia.eu12.appfront.cloud.sap # temp: hardcoded App Front URL

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ gen
 node_modules
 .env
 .cf
+*.mtar
+dist
 
 # added by cds
 .cdsrc-private.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .env
 .cf
 *.mtar
+*.mtaext
 dist
 
 # added by cds

--- a/app/travels/package.json
+++ b/app/travels/package.json
@@ -1,41 +1,16 @@
 {
   "name": "travel-processor",
   "version": "1.0.0",
-  "private": true,
   "main": "webapp/index.html",
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "scripts": {
     "build": "ui5 build preload --clean-dest --include-task=generateCachebusterInfo",
-    "start": "ui5 serve",
-    "test": "npm run test:node && npm run test:java",
-    "test:java": "karma start --server=java --single-run",
-    "test:node": "karma start --server=node --single-run",
-    "ts-typecheck": "tsc --noEmit",
-    "prestart": "npm run ts-typecheck",
-    "prebuild": "npm run ts-typecheck",
-    "deploy-config": "npx -p @sap/ux-ui5-tooling fiori add deploy-config cf"
+    "start": "ui5 serve"
   },
-  "keywords": [
-    "ui5",
-    "openui5",
-    "sapui5"
-  ],
   "devDependencies": {
-    "@sap/ux-ui5-tooling": "1",
-    "@sapui5/types": "^1.130.0",
-    "@typescript-eslint/eslint-plugin": "^8",
-    "@typescript-eslint/parser": "^8",
     "@ui5/cli": "^4.0.0",
-    "karma": "^6.4.3",
-    "karma-chrome-launcher": "^3.2.0",
-    "karma-ui5": "^4.0.1",
-    "karma-ui5-transpile": "^3.5.1",
-    "puppeteer": "^24",
-    "typescript": "^5.1.6",
-    "ui5-middleware-simpleproxy": "^3.2.16",
-    "ui5-task-zipper": "^3.1.4",
-    "ui5-tooling-transpile": "^3.3.7"
+    "ui5-task-zipper": "^3.1.4"
   }
 }

--- a/app/travels/public/manifest.json
+++ b/app/travels/public/manifest.json
@@ -1,0 +1,13 @@
+{
+  "_version": "1.49.0",
+  "sap.app": {
+    "id": "xtravels.travels",
+    "applicationVersion": {
+      "version": "1.0.0"
+    },
+    "type": "application",
+    "title": "CAP XTravels",
+    "description": "CAP XTravels sample application",
+    "i18n": "i18n/i18n.properties"
+  }
+}

--- a/app/travels/ui5.yaml
+++ b/app/travels/ui5.yaml
@@ -20,10 +20,7 @@ builder:
         archiveName: travel-processor
         additionalFiles:
           - xs-app.json
-    - name: ui5-tooling-transpile-task
-      afterTask: replaceVersion
-      # configuration:
-        # debug: true
+        relativePaths: true
 
 server:
   customMiddleware:
@@ -36,9 +33,3 @@ server:
         password: admin # dummy credentials for local testing
     - name: fiori-tools-appreload
       afterMiddleware: compression
-    - name: ui5-tooling-transpile-middleware
-      afterMiddleware: compression
-      configuration:
-        # debug: true
-        excludePatterns:
-          - /Component-preload.js

--- a/app/travels/xs-app.json
+++ b/app/travels/xs-app.json
@@ -3,17 +3,15 @@
   "authenticationMethod": "route",
   "routes": [
     {
-      "source": "^/processor/(.*)$",
-      "target": "/processor/$1",
-      "destination": "sflight-srv",
+      "source": "^/?(odata|hcql|rest)/(.*)$",
+      "target": "/$1/$2",
+      "destination": "srv-api",
       "authenticationType": "xsuaa",
       "csrfProtection": false
     },
     {
-      "source": "^(.*)$",
-      "target": "$1",
-      "service": "html5-apps-repo-rt",
-      "authenticationType": "xsuaa"
+      "source": ".*",
+      "service": "app-front"
     }
   ]
 }

--- a/mta.yaml
+++ b/mta.yaml
@@ -5,6 +5,7 @@ description: "CAP XTravels sample application"
 parameters:
   enable-parallel-deployments: true
   deploy_mode: html5-repo
+  s4-api-key: "" # S/4 sandbox APIKey; real value injected at deploy time via .mtaext (never committed)
 build-parameters:
   before-all:
     - builder: custom
@@ -109,6 +110,12 @@ resources:
                 ProxyType: Internet
                 Type: HTTP
                 HTML5.ForwardAuthToken: true
+              - Name: s4-dest
+                URL: https://sandbox.api.sap.com/s4hanacloud
+                Authentication: NoAuthentication
+                ProxyType: Internet
+                Type: HTTP
+                URL.headers.APIKey: ${s4-api-key}
 
   - name: xtravels-app-front
     type: org.cloudfoundry.managed-service

--- a/mta.yaml
+++ b/mta.yaml
@@ -1,0 +1,117 @@
+_schema-version: 3.3.0
+ID: capire.xtravels
+version: 1.0.1
+description: "CAP XTravels sample application"
+parameters:
+  enable-parallel-deployments: true
+  deploy_mode: html5-repo
+build-parameters:
+  before-all:
+    - builder: custom
+      commands:
+        - npm ci
+        - npx cds build --production --ws-pack
+modules:
+  - name: xtravels-srv
+    type: nodejs
+    path: gen/srv
+    parameters:
+      instances: 1
+      buildpack: nodejs_buildpack
+      readiness-health-check-type: http
+      readiness-health-check-http-endpoint: /health
+      disk-quota: 1024M
+      memory: 1024M
+    build-parameters:
+      builder: npm-ci
+    provides:
+      - name: srv-api # required by consumers of CAP services (e.g. approuter)
+        properties:
+          srv-url: ${default-url}
+    requires:
+      - name: xtravels-db
+      - name: xtravels-auth
+      - name: xtravels-destination
+
+  - name: xtravels-db-deployer
+    type: hdb
+    path: gen/db
+    parameters:
+      buildpack: nodejs_buildpack
+    requires:
+      - name: xtravels-db
+
+  - name: xtravels-app-deployer
+    type: com.sap.application.content
+    path: gen
+    build-parameters:
+      build-result: app/
+      requires:
+        - name: travel-processor
+          artifacts:
+            - travel-processor.zip
+          target-path: app/
+    requires:
+      - name: xtravels-auth
+      - name: srv-api
+      - name: xtravels-app-front
+        parameters:
+          content-target: true
+    parameters:
+      config:
+        destinations:
+          - name: srv-api
+            url: ~{srv-api/srv-url}
+            forwardAuthToken: true
+          - name: ui5
+            url: https://ui5.sap.com
+
+  - name: travel-processor
+    type: html5
+    path: app/travels
+    build-parameters:
+      build-result: dist
+      builder: custom
+      commands:
+        - npm ci
+        - npm run build
+      supported-platforms: []
+
+resources:
+  - name: xtravels-db
+    type: com.sap.xs.hdi-container
+    parameters:
+      service: hana
+      service-plan: hdi-shared
+
+  - name: xtravels-auth
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: xsuaa
+      service-plan: application
+      config:
+        xsappname: xtravels-${org}-${space}
+        tenant-mode: dedicated
+
+  - name: xtravels-destination
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: destination
+      service-plan: lite
+      config:
+        init_data:
+          instance:
+            existing_destinations_policy: update
+            destinations:
+              - Name: flights-dest
+                URL: https://cap-sandbox-capire-xflights-srv.cfapps.eu12.hana.ondemand.com
+                Authentication: NoAuthentication
+                ProxyType: Internet
+                Type: HTTP
+                HTML5.ForwardAuthToken: true
+
+  - name: xtravels-app-front
+    type: org.cloudfoundry.managed-service
+    parameters:
+      service: app-front
+      service-plan: developer

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CAP XTravels sample application",
   "scripts": {
     "lint": "npx eslint .",
-    "start": "cds-serve",
+    "start": "cds-serve --with-mocks",
     "test": "cds test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,5 +17,18 @@
     "@cap-js/cds-test": "^1",
     "@cap-js/sqlite": "^3"
   },
+  "cds": {
+    "requires": {
+      "[production]": {
+        "FlightsService": {
+          "kind": "hcql",
+          "credentials": {
+            "destination": "flights-dest",
+            "path": "/hcql/flights"
+          }
+        }
+      }
+    }
+  },
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CAP XTravels sample application",
   "scripts": {
     "lint": "npx eslint .",
-    "start": "cds-serve --with-mocks",
+    "start": "cds-serve",
     "test": "cds test"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
             "destination": "flights-dest",
             "path": "/hcql/flights"
           }
+        },
+        "sap.capire.s4.business-partner": {
+          "kind": "odata-v2",
+          "credentials": {
+            "destination": "s4-dest",
+            "path": "/sap/opu/odata/sap/API_BUSINESS_PARTNER"
+          }
         }
       }
     }

--- a/srv/travel-service/service.js
+++ b/srv/travel-service/service.js
@@ -18,13 +18,13 @@ class TravelService extends cds.ApplicationService {
    */
   async service_integration() {
 
-    // const s4 = await cds.connect.to ('sap.capire.s4.business-partner')
+    const s4 = await cds.connect.to ('sap.capire.s4.business-partner')
     const xflights = await cds.connect.to ('FlightsService')
     const yfligths = cds.outboxed (xflights)
     const { Flights, Travels, Customers } = this.entities
 
     // Delegate value help requests on Customers to S4 Business Partner service
-    // this.on ('READ', Customers, req =>  s4.run (req.query))
+    this.on ('READ', Customers, req =>  s4.run (req.query))
 
     // Inform XFlights about new bookings, so it can update occupied seats
     this.after ('SAVE', Travels, ({ Bookings=[] }) => {

--- a/srv/travel-service/service.js
+++ b/srv/travel-service/service.js
@@ -18,13 +18,13 @@ class TravelService extends cds.ApplicationService {
    */
   async service_integration() {
 
-    const s4 = await cds.connect.to ('sap.capire.s4.business-partner')
+    // const s4 = await cds.connect.to ('sap.capire.s4.business-partner')
     const xflights = await cds.connect.to ('FlightsService')
     const yfligths = cds.outboxed (xflights)
     const { Flights, Travels, Customers } = this.entities
 
-    // Delegate value helpp requests on Customers to S4 Business Partner service
-    this.on ('READ', Customers, req =>  s4.run (req.query))
+    // Delegate value help requests on Customers to S4 Business Partner service
+    // this.on ('READ', Customers, req =>  s4.run (req.query))
 
     // Inform XFlights about new bookings, so it can update occupied seats
     this.after ('SAVE', Travels, ({ Bookings=[] }) => {


### PR DESCRIPTION
Adds a Cloud Foundry deployment pipeline for xtravels (`mta.yaml` and a `cds up` GitHub workflow) that deploys to the Staging environment after merges to `main`. For test purposes deployed in this PR:
https://github.com/capire/xtravels/deployments/Staging

  The S/4 Business Partner value help now uses SAP's public Business Accelerator Hub sandbox (`sandbox.api.sap.com/s4hanacloud`) through an `s4-dest` destination. The sandbox `APIKey` comes from the
  `S4_KEY` GitHub secret via an `.mtaext` overlay at deploy time, so it's never committed.