### PR TITLE
chore: add `type: "module"` to ESM

### DIFF
--- a/srv/events/package.json
+++ b/srv/events/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@capire/events",
   "version": "1.0.0",
+  "type": "module",
   "dependencies": {
     "@cap-js/sqlite": "*",
     "@cap-js/mcp": "*"

--- a/srv/hotels/package.json
+++ b/srv/hotels/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@capire/hotels",
   "version": "1.0.0",
+  "type": "module",
   "dependencies": {
     "@cap-js/sqlite": "*",
     "@cap-js/mcp": "*"


### PR DESCRIPTION
Also need `NODE_OPTIONS=--experimental-vm-modules` in order not to break `cap/dev` tests.